### PR TITLE
Fix Route 280 loading the wrong title card texture.

### DIFF
--- a/CharacterSelectPlus/Base.cpp
+++ b/CharacterSelectPlus/Base.cpp
@@ -1215,7 +1215,7 @@ void LoadTitleCardTextures()
 		{
 		case Characters_Knuckles:
 		case Characters_Rouge:
-			v15 = "KN";
+			v15 = "RO";
 			break;
 		case Characters_Tails:
 		case Characters_Eggman:


### PR DESCRIPTION
The function that loads the title card textures incorrectly loads the textures for Knuckles when loading Route 280, I've changed it to use Rouge's textures instead.